### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/titan-data/s3web-remote-go
+module github.com/titan-data/ssh-remote-go
 
 require (
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
## Issues Addressed

parsing go.mod:
        module declares its path as: github.com/titan-data/s3web-remote-go
                but was required as: github.com/titan-data/ssh-remote-go
