### PR TITLE
implement server APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/titan-data/ssh-remote-go
 
 require (
 	github.com/stretchr/testify v1.4.0
-	github.com/titan-data/remote-sdk-go v0.1.0
+	github.com/titan-data/remote-sdk-go v0.2.1
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.10.1 h1:uyt/l0dWjJ879yiAu+T7FG3/6QX+zwm4bQ8P7XsYt3o=
 github.com/hashicorp/go-hclog v0.10.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.11.0 h1:zf3QG3ap4KOMHzDLxBvq9ZtEFVSxQzVdH1ccl5NK2tU=
+github.com/hashicorp/go-hclog v0.11.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
@@ -37,6 +39,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -48,6 +51,8 @@ github.com/titan-data/remote-sdk-go v0.0.3 h1:kGLc7JP7znTcXyl3gRML2jEST99ebdhz0C
 github.com/titan-data/remote-sdk-go v0.0.3/go.mod h1:b4McaOFiLYWv2/wCQW/sE2BcCSNz/Ae6iKKEtqw703w=
 github.com/titan-data/remote-sdk-go v0.1.0 h1:Xab4sduqyGdo04eJ5mQ2lIfAYZDjHJ4AzlK4oJ5EqqE=
 github.com/titan-data/remote-sdk-go v0.1.0/go.mod h1:u7w3Olu3EtjoFcHzxUOzelxedey4q2nveuKLvgRO7tg=
+github.com/titan-data/remote-sdk-go v0.2.1 h1:Aa1CWqSbPIIvuacy27nMcbmLF2eymLIJs8m+yW8ki8E=
+github.com/titan-data/remote-sdk-go v0.2.1/go.mod h1:IYCrMWL1hFGoYusrTHgseG/bLVuY72LpQSSdGOrcHb4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/ssh/mock_test.go
+++ b/ssh/mock_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package ssh
+
+import (
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/crypto/ssh"
+	"net"
+)
+
+type MockConn struct {
+	mock.Mock
+}
+
+func (m *MockConn) User() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockConn) SessionID() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+func (m *MockConn) ClientVersion() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+func (m *MockConn) ServerVersion() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	args := m.Called()
+	return args.Get(0).(net.Addr)
+}
+
+func (m *MockConn) LocalAddr() net.Addr {
+	args := m.Called()
+	return args.Get(0).(net.Addr)
+}
+
+func (m *MockConn) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	args := m.Called(name, wantReply, payload)
+	return args.Bool(0), args.Get(1).([]byte), args.Error(2)
+}
+
+func (m MockConn) OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	args := m.Called(name, data)
+	return args.Get(0).(ssh.Channel), args.Get(1).(<-chan *ssh.Request), args.Error(2)
+}
+
+func (m MockConn) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m MockConn) Wait() error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -139,6 +139,22 @@ func (s sshRemote) GetParameters(remoteProperties map[string]interface{}) (map[s
 	return result, nil
 }
 
+func (s sshRemote) ValidateRemote(properties map[string]interface{}) error {
+	panic("implement me")
+}
+
+func (s sshRemote) ValidateParameters(parameters map[string]interface{}) error {
+	panic("implement me")
+}
+
+func (s sshRemote) ListCommits(properties map[string]interface{}, parameters map[string]interface{}, tags []remote.Tag) ([]remote.Commit, error) {
+	panic("implement me")
+}
+
+func (s sshRemote) GetCommit(properties map[string]interface{}, parameters map[string]interface{}, commitId string) (*remote.Commit, error) {
+	panic("implement me")
+}
+
 func init() {
 	remote.Register(sshRemote{})
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -140,11 +140,30 @@ func (s sshRemote) GetParameters(remoteProperties map[string]interface{}) (map[s
 }
 
 func (s sshRemote) ValidateRemote(properties map[string]interface{}) error {
-	panic("implement me")
+	err := remote.ValidateFields(properties, []string{"username", "address", "path"}, []string{"password", "port", "keyFile"})
+	if err != nil {
+		return err
+	}
+	if port, ok := properties["port"]; ok {
+		portval := 0
+		if p, ok := port.(int); ok {
+			portval = p
+		}
+		if p, ok := port.(float32); ok {
+			portval = int(p)
+		}
+		if p, ok := port.(float64); ok {
+			portval = int(p)
+		}
+		if portval <= 0 || portval > 65535 {
+			return errors.New("invalid port")
+		}
+	}
+	return nil
 }
 
 func (s sshRemote) ValidateParameters(parameters map[string]interface{}) error {
-	panic("implement me")
+	return remote.ValidateFields(parameters, []string{}, []string{"password", "key"})
 }
 
 func (s sshRemote) ListCommits(properties map[string]interface{}, parameters map[string]interface{}, tags []remote.Tag) ([]remote.Commit, error) {

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -281,3 +281,76 @@ func TestBadPasswordPrompt(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestValidateRemoteRequiredOnly(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path"})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemoteAllOptional(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"keyFile": "/keyfile", "password": "password", "port": 8022})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemoteBadPort(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"keyFile": "/keyfile", "password": "password", "port": "foo"})
+	assert.Error(t, err)
+}
+
+func TestValidateRemoteBadPortNegative(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"keyFile": "/keyfile", "password": "password", "port": -1})
+	assert.Error(t, err)
+}
+
+func TestValidateRemotePortFloat(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"keyFile": "/keyfile", "password": "password", "port": 22.0})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemotePortFloat32(t *testing.T) {
+	r := remote.Get("ssh")
+	var p float32 = 22.0
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"keyFile": "/keyfile", "password": "password", "port": p})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemoteMissingRequired(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host"})
+	assert.Error(t, err)
+}
+
+func TestValidateRemoteExtraProperty(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateRemote(map[string]interface{}{"username": "username", "address": "host", "path": "/path",
+		"foo": "bar"})
+	assert.Error(t, err)
+}
+
+func TestValidateParametersEmpty(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateParameters(map[string]interface{}{})
+	assert.NoError(t, err)
+}
+
+func TestValidateParametersAllOptional(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateParameters(map[string]interface{}{"key": "key", "password": "password"})
+	assert.NoError(t, err)
+}
+
+func TestValidateParametersUnknown(t *testing.T) {
+	r := remote.Get("ssh")
+	err := r.ValidateParameters(map[string]interface{}{"foo": "bar"})
+	assert.Error(t, err)
+}

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -17,201 +17,234 @@ import (
 
 func TestRegistered(t *testing.T) {
 	r := remote.Get("ssh")
-	ret, _ := r.Type()
-	assert.Equal(t, "ssh", ret)
+	ret, err := r.Type()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh", ret)
+	}
 }
 
 func TestFromURL(t *testing.T) {
 	r := remote.Get("ssh")
-	props, _ := r.FromURL("ssh://user:pass@host:8022/path", map[string]string{})
-	assert.Equal(t, "user", props["username"])
-	assert.Equal(t, "pass", props["password"])
-	assert.Equal(t, "host", props["address"])
-	assert.Equal(t, 8022, props["port"])
-	assert.Equal(t, "/path", props["path"])
-	assert.Nil(t, props["keyFile"])
+	props, err := r.FromURL("ssh://user:pass@host:8022/path", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "user", props["username"])
+		assert.Equal(t, "pass", props["password"])
+		assert.Equal(t, "host", props["address"])
+		assert.Equal(t, 8022, props["port"])
+		assert.Equal(t, "/path", props["path"])
+		assert.Nil(t, props["keyFile"])
+	}
 }
 
 func TestSimple(t *testing.T) {
 	r := remote.Get("ssh")
-	props, _ := r.FromURL("ssh://user@host/path", map[string]string{})
-	assert.Equal(t, "user", props["username"])
-	assert.Nil(t, props["password"])
-	assert.Equal(t, "host", props["address"])
-	assert.Nil(t, props["port"])
-	assert.Equal(t, "/path", props["path"])
-	assert.Nil(t, props["keyFile"])
+	props, err := r.FromURL("ssh://user@host/path", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "user", props["username"])
+		assert.Nil(t, props["password"])
+		assert.Equal(t, "host", props["address"])
+		assert.Nil(t, props["port"])
+		assert.Equal(t, "/path", props["path"])
+		assert.Nil(t, props["keyFile"])
+	}
 }
 
 func TestKeyFile(t *testing.T) {
 	r := remote.Get("ssh")
-	props, _ := r.FromURL("ssh://user@host/path", map[string]string{"keyFile": "~/.ssh/id_dsa"})
-	assert.Equal(t, "~/.ssh/id_dsa", props["keyFile"])
+	props, err := r.FromURL("ssh://user@host/path", map[string]string{"keyFile": "~/.ssh/id_dsa"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "~/.ssh/id_dsa", props["keyFile"])
+	}
 }
 
 func TestRelativePath(t *testing.T) {
 	r := remote.Get("ssh")
-	props, _ := r.FromURL("ssh://user@host/~/relative/path", map[string]string{})
-	assert.Equal(t, "relative/path", props["path"])
+	props, err := r.FromURL("ssh://user@host/~/relative/path", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "relative/path", props["path"])
+	}
 }
 
 func TestBadScheme(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("foo://user:pass@host:8022/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadPasswordAndKeyFile(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://user:password@host/path", map[string]string{"keyFile": "~/.ssh/id_dsa"})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadProperty(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://user@host/path", map[string]string{"foo": "bar"})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadMissingHost(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh:///path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadSchemeOnly(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadMissingUsername(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://host/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadPort(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://user@host:29348529384572398457932847539/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadMissingPath(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://user@host", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadMissingHostWithUser(t *testing.T) {
 	r := remote.Get("ssh")
 	_, err := r.FromURL("ssh://user@/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestToURL(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path"})
-	assert.Equal(t, "ssh://username@host/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestToPassword(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "password": "pass"})
-	assert.Equal(t, "ssh://username:*****@host/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username:*****@host/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestToPort(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "port": 812})
-	assert.Equal(t, "ssh://username@host:812/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host:812/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestToRelativePath(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "path"})
-	assert.Equal(t, "ssh://username@host/~/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host/~/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestToKeyFile(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "keyFile": "keyfile"})
-	assert.Equal(t, "ssh://username@host/path", u)
-	assert.Len(t, props, 1)
-	assert.Equal(t, "keyfile", props["keyFile"])
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host/path", u)
+		assert.Len(t, props, 1)
+		assert.Equal(t, "keyfile", props["keyFile"])
+	}
 }
 
 func TestToPortFloat(t *testing.T) {
 	p := float32(812)
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "port": p})
-	assert.Equal(t, "ssh://username@host:812/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host:812/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestToPortDouble(t *testing.T) {
 	r := remote.Get("ssh")
-	u, props, _ := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
+	u, props, err := r.ToURL(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "port": 812.0})
-	assert.Equal(t, "ssh://username@host:812/path", u)
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "ssh://username@host:812/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestGetParameters(t *testing.T) {
 	r := remote.Get("ssh")
-	props, _ := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
+	props, err := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "password": "pass"})
-	assert.Empty(t, props)
+	if assert.NoError(t, err) {
+		assert.Empty(t, props)
+	}
 }
 
 func TestKeyFileParameters(t *testing.T) {
 	r := remote.Get("ssh")
 	file, err := ioutil.TempFile("", "ssh.test")
-	if err != nil {
-		t.Fatal(err)
+	if !assert.NoError(t, err) {
+		return
 	}
 	defer os.Remove(file.Name())
 	path, err := filepath.Abs(file.Name())
-	if err != nil {
-		t.Fatal(err)
+	if !assert.NoError(t, err) {
+		return
 	}
 
 	err = ioutil.WriteFile(path, []byte("KEY"), 0600)
-	if err != nil {
-		t.Fatal(err)
+	if !assert.NoError(t, err) {
+		return
 	}
 
-	props, _ := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
+	props, err := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path", "keyFile": path})
-	assert.Nil(t, props["password"])
-	assert.Equal(t, "KEY", props["key"])
+	if assert.NoError(t, err) {
+		assert.Nil(t, props["password"])
+		assert.Equal(t, "KEY", props["key"])
+	}
 }
 
 func TestBadKeyFileParameters(t *testing.T) {
 	r := remote.Get("ssh")
 	file, err := ioutil.TempFile("", "ssh.test")
-	if err != nil {
-		t.Fatal(err)
+	if !assert.NoError(t, err) {
+		return
 	}
 	path, err := filepath.Abs(file.Name())
-	if err != nil {
-		t.Fatal(err)
+	if !assert.NoError(t, err) {
+		return
 	}
-	os.Remove(path)
-
-	_, err = r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
-		"path": "/path", "keyFile": path})
-	assert.NotNil(t, err)
+	err = file.Close()
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = os.Remove(path)
+	if assert.NoError(t, err) {
+		_, err = r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
+			"path": "/path", "keyFile": path})
+		assert.Error(t, err)
+	}
 }
 
 func TestPasswordPrompt(t *testing.T) {
@@ -222,13 +255,15 @@ func TestPasswordPrompt(t *testing.T) {
 	fmtPrintf = func(format string, a ...interface{}) (n int, err error) {
 		return 0, nil
 	}
-	props, _ := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
+	props, err := r.GetParameters(map[string]interface{}{"username": "username", "address": "host",
 		"path": "/path"})
-	readPassword = terminal.ReadPassword
-	fmtPrintf = fmt.Printf
+	if assert.NoError(t, err) {
+		readPassword = terminal.ReadPassword
+		fmtPrintf = fmt.Printf
 
-	assert.Nil(t, props["key"])
-	assert.Equal(t, "pass", props["password"])
+		assert.Nil(t, props["key"])
+		assert.Equal(t, "pass", props["password"])
+	}
 }
 
 func TestBadPasswordPrompt(t *testing.T) {
@@ -244,5 +279,5 @@ func TestBadPasswordPrompt(t *testing.T) {
 	readPassword = terminal.ReadPassword
 	fmtPrintf = fmt.Printf
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Proposed Changes

This adds the new server APIs for getting and listing commits.

## Testing

`go test ./...`. This doesn't actually do end2end testing, only mocked SSH. Once I get it validated within the context of `titan-server`, I'm going to pull out the end2en test library from `titan-server` and move the endtoend tests over to the individual remotes.